### PR TITLE
Add  publish to winget workflow

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -1,0 +1,13 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Kameleo.App
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Add workflow file to automatically publish releases to winget repository.
Docs: https://github.com/marketplace/actions/winget-releaser