### PR TITLE
Use HOMEBREW_TOKEN for winget publish

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           identifier: Kameleo.App
           max-versions-to-keep: 5
-          token: ${{ secrets.WINGET_TOKEN }}
+          token: ${{ secrets.HOMEBREW_TOKEN }}
           version:   ${{ inputs.version || github.event.release.tag_name }}
           release-tag: ${{ inputs.version || github.event.release.tag_name }}


### PR DESCRIPTION
The homebrew token has the same level of access as the expired winget token had.